### PR TITLE
gateware/common.py, gateware/LimeDFB_LiteX/tx_path_top/src/tx_path_top.py: set flatten_source parameter to False to avoid out of resources failure (#6)

### DIFF
--- a/gateware/LimeDFB_LiteX/tx_path_top/src/tx_path_top.py
+++ b/gateware/LimeDFB_LiteX/tx_path_top/src/tx_path_top.py
@@ -196,9 +196,10 @@ class TXPathTop(LiteXModule):
         force_convert = platform.vhd2v_force
         # May be problematic if we need to use fifo somewhere else
         self.fifo_src_conv =  VHD2VConverter(platform,
-                              work_package  = "work",
-                              force_convert = True,#force_convert,
-                              add_instance  = False,
+                              work_package   = "work",
+                              force_convert  = True,#force_convert,
+                              flatten_source = False,
+                              add_instance   = False,
                               files    = ["gateware/LimeDFB/axis_fifo/src/axis_fifo.vhd",
                                           "gateware/LimeDFB/axis_fifo/src/wptr_handler.vhd",
                                           "gateware/LimeDFB/axis_fifo/src/rptr_handler.vhd",

--- a/gateware/common.py
+++ b/gateware/common.py
@@ -39,9 +39,10 @@ def FromFPGACfg():
 def add_vhd2v_converter(platform, instance, files=[], force_convert=None):
     force_convert = {True: platform.vhd2v_force, False: force_convert}[force_convert is None]
     return VHD2VConverter(platform,
-        instance      = instance,
-        work_package  = "work",
-        force_convert = force_convert,
-        add_instance  = True,
-        files         = files,
+        instance       = instance,
+        work_package   = "work",
+        force_convert  = force_convert,
+        flatten_source = False, # disabled to avoid an out of resources error
+        add_instance   = True,
+        files          = files,
     )


### PR DESCRIPTION
`VHD2VConverter` with [commit](https://github.com/enjoy-digital/litex/commit/89bc7da258a302cb5855b6dce36cb29dd34bfed0) now uses `yosys` to flatten source when this tool is present. But this step seems to introduces additional resources usage.

With [commit](https://github.com/enjoy-digital/litex/commit/138379f3da81dad445970f8ca28a98cd7e4d29eb) this step may be bypassed to have same behavior as before flatten introduction.

Fix the issue #6 for both LimeSDR XTRX and LimeSDR Mini v2